### PR TITLE
added more computable cases to rational torsion order

### DIFF
--- a/sage_modabvar/abvar.py
+++ b/sage_modabvar/abvar.py
@@ -2160,9 +2160,13 @@ class ModularAbelianVariety_abstract(ParentWithBase):
             1
 
             sage: J1(17).number_of_rational_points()
+            584
+
+            sage: J1(14).number_of_rational_points()
             Traceback (most recent call last):
             ...
-            NotImplementedError: computation of rational cusps only implemented in Gamma0 case.
+            RuntimeError: Unable to compute order of torsion subgroup (it is in [1, 2, 3, 6])
+
         """
         # Check easy dimension zero case
         if self.dimension() == 0:


### PR DESCRIPTION
The three main changes are:
1. Added the J0(p) case to order() which got tested against the old method.
2. Added the J1(p) case to divisor_of_order() which got checked against Table 1 here: http://www.wstein.org/papers/j1p/12.pdf
3. divisor_of_order() now returns at least 1 in Gamma1 cases instead of raising an error.
