### PR TITLE
implemented newform_decomposition

### DIFF
--- a/sage_modabvar/abvar.py
+++ b/sage_modabvar/abvar.py
@@ -62,6 +62,7 @@ from sage.functions.other       import real
 
 from copy import copy
 
+import constructor
 import homology
 import homspace
 import lseries
@@ -514,7 +515,7 @@ class ModularAbelianVariety_abstract(ParentWithBase):
         """
         degen = str(self.degen_t()).replace(' ','')
         return '%s%s'%(self.newform_label(), degen)
-    
+
     def newform(self, names=None):
         """
         Return the newform `f` such that this abelian variety is isogenous to
@@ -554,6 +555,25 @@ class ModularAbelianVariety_abstract(ParentWithBase):
             ValueError: self must be simple
         """
         return Newform(self.newform_label(), names=names)
+
+    def newform_decomposition(self, names=None):
+        """
+        Return the newforms of the simple subvarieties in the decomposition of
+        self as a product of simple subvarieties, up to isogeny.
+
+        OUTPUT:
+
+            - an array of newforms
+
+        EXAMPLES::
+
+            sage: from sage_modabvar import J0, J1
+            sage: J = J1(11) * J0(23)
+            sage: J.newform_decomposition('a')
+            [q - 2*q^2 - q^3 + 2*q^4 + q^5 + O(q^6),
+            q + a0*q^2 + (-2*a0 - 1)*q^3 + (-a0 - 1)*q^4 + 2*a0*q^5 + O(q^6)]
+        """
+        return [S.newform(names=names) for S in self.decomposition()]
 
     def newform_label(self):
         """
@@ -2369,8 +2389,10 @@ class ModularAbelianVariety_abstract(ParentWithBase):
         if not is_prime(p):
             raise ValueError("p must be prime")
         if not self.is_simple():
+            decomp = [constructor.AbelianVariety(f) for f in
+                      self.newform_decomposition('a')]
             return prod((s.frobenius_polynomial(p) for s in
-                         self.decomposition()))
+                         decomp))
         f = self.newform('a')
         Kf = f.base_ring()
         eps = f.character()

--- a/sage_modabvar/abvar_ambient_jacobian.py
+++ b/sage_modabvar/abvar_ambient_jacobian.py
@@ -16,9 +16,11 @@ from sage.structure.sequence import Sequence
 from abvar             import (ModularAbelianVariety_modsym_abstract, ModularAbelianVariety,
                                simple_factorization_of_modsym_space, modsym_lattices,
                                ModularAbelianVariety_modsym)
-from sage.rings.all    import QQ
+from sage.rings.all    import QQ, Integer
 
 from sage.modular.modsym.modsym import ModularSymbols
+from sage.modular.modform.constructor import Newforms
+from sage.modular.arithgroup.all import is_Gamma0, is_Gamma1
 import morphism
 
 
@@ -405,6 +407,33 @@ class ModAbVar_ambient_jacobian_class(ModularAbelianVariety_modsym_abstract):
         self.__decomposition[simple] = D
         return D
 
+    def newform_decomposition(self, names=None):
+        """
+        Return the newforms of the simple subvarieties in the decomposition of
+        self as a product of simple subvarieties, up to isogeny.
 
+        OUTPUT:
 
+            - an array of newforms
 
+        EXAMPLES::
+
+            sage: from sage_modabvar import J0, J1
+            sage: J0(81).newform_decomposition('a')
+            [q - 2*q^4 + O(q^6), q - 2*q^4 + O(q^6), q + a0*q^2 + q^4 - a0*q^5 + O(q^6)]
+
+            sage: J1(19).newform_decomposition('a')
+            [q - 2*q^3 - 2*q^4 + 3*q^5 + O(q^6),
+             q + a1*q^2 + (-1/9*a1^5 - 1/3*a1^4 - 1/3*a1^3 + 1/3*a1^2 - a1 - 1)*q^3 + (4/9*a1^5 + 2*a1^4 + 14/3*a1^3 + 17/3*a1^2 + 6*a1 + 2)*q^4 + (-2/3*a1^5 - 11/3*a1^4 - 10*a1^3 - 14*a1^2 - 15*a1 - 9)*q^5 + O(q^6)]
+        """
+        if self.dimension() == 0:
+            return []
+        G = self.group()
+        if not (is_Gamma0(G) or is_Gamma1(G)):
+            return [S.newform(names=names) for S in self.decomposition()]
+        Gtype = G.parent()
+        N = G.level()
+        preans = [Newforms(Gtype(d), names=names) *
+                  len(Integer(N/d).divisors()) for d in N.divisors()]
+        ans = [newform for l in preans for newform in l]
+        return ans

--- a/sage_modabvar/lseries.py
+++ b/sage_modabvar/lseries.py
@@ -138,13 +138,7 @@ class Lseries_complex(Lseries):
         except KeyError:
             pass
         abelian_variety = self.abelian_variety()
-        # Check for easy J0 case
-        if abelian_variety.is_J0():
-            S = CuspForms(abelian_variety.level())
-            newforms = S.newforms('a')
-        else:
-            simples = abelian_variety.decomposition()
-            newforms = [simple.newform('a') for simple in simples]
+        newforms = abelian_variety.newform_decomposition('a')
 
         factors = [newform.lseries(embedding=i, prec=prec)
                 for newform in newforms


### PR DESCRIPTION
Sometimes we just want the newforms and calling decomposition() does too much work so I implemented newform_decomposition() which just returns the newforms. Up to a re-ordering, it is equivalent to `[S.newform(names=names) for S in self.decomposition()]` . 

The performance is much better, especially in the J1 case.
