### PR TITLE
Moved some code from order() to possible_orders() in torsion_subgroup…

### DIFF
--- a/sage_modabvar/abvar.py
+++ b/sage_modabvar/abvar.py
@@ -2330,11 +2330,10 @@ class ModularAbelianVariety_abstract(ParentWithBase):
             sage: J1(17).number_of_rational_points()
             584
 
-            sage: J1(14).number_of_rational_points()
+            sage: J1(16).number_of_rational_points()
             Traceback (most recent call last):
             ...
-            RuntimeError: Unable to compute order of torsion subgroup (it is in [1, 2, 3, 6])
-
+            RuntimeError: Unable to compute order of torsion subgroup (it is in [1, 2, 4, 5, 10, 20])
         """
         # Check easy dimension zero case
         if self.dimension() == 0:
@@ -2823,7 +2822,8 @@ class ModularAbelianVariety_abstract(ParentWithBase):
             sage: A = J.new_subvariety()
             sage: A
             Abelian subvariety of dimension 1 of J0(33)
-            sage: t = A.rational_torsion_subgroup()
+            sage: t = A.rational_torsion_subgroup(); t
+            Torsion subgroup of Abelian subvariety of dimension 1 of J0(33)
             sage: t.multiple_of_order()
             4
             sage: t.divisor_of_order()
@@ -2832,8 +2832,6 @@ class ModularAbelianVariety_abstract(ParentWithBase):
             4
             sage: t.gens()
             [[(1/2, 0, 0, -1/2, 0, 0)], [(0, 0, 1/2, 0, 1/2, -1/2)]]
-            sage: t
-            Torsion subgroup of Abelian subvariety of dimension 1 of J0(33)
         """
         try:
             return self.__rational_torsion_subgroup

--- a/sage_modabvar/torsion_subgroup.py
+++ b/sage_modabvar/torsion_subgroup.py
@@ -209,13 +209,6 @@ class RationalTorsionSubgroup(FiniteSubgroup):
         except AttributeError:
             pass
 
-        # return the order of the cuspidal subgroup in the J0(p) case
-        A = self.abelian_variety()
-        if (A.is_ambient() and len(A.groups()) == 1 and
-                is_Gamma0(A.group()) and A.level().is_prime()):
-            self._order = QQ((A.level()-1)/12).numerator()
-            return self._order
-
         O = self.possible_orders()
         if len(O) == 1:
             n = O[0]
@@ -292,13 +285,23 @@ class RationalTorsionSubgroup(FiniteSubgroup):
             sage: from sage_modabvar import J1
             sage: J1(13).rational_torsion_subgroup().possible_orders()
             [19]
-            sage: J1(15).rational_torsion_subgroup().possible_orders()
-            [1, 2, 4, 8]
+            sage: J1(16).rational_torsion_subgroup().possible_orders()
+            [1, 2, 4, 5, 10, 20]
         """
         try:
             return self._possible_orders
         except AttributeError:
             pass
+
+        # return the order of the cuspidal subgroup in the J0(p) case
+        A = self.abelian_variety()
+        if A.is_J0() and A.level().is_prime():
+            self._order = QQ((A.level()-1)/12).numerator()
+            return [self._order]
+
+        if A.dimension() == 1:
+            return [A.elliptic_curve().torsion_order()]
+
         u = self.multiple_of_order()
         l = self.divisor_of_order()
 


### PR DESCRIPTION
We know the rational torsion order of J0(p) explicitly and the rational torsion order of elliptic curves. Should the multiple_of_order and divisor_of_order code reflect this? 
